### PR TITLE
Use latest planemo version from GitHub

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ bioblend==0.18.0
 ephemeris==0.10.7
 Flask==2.1.3
 gunicorn==19.9.0
-planemo==0.74.11
+git+https://github.com/galaxyproject/planemo.git@master
 pyaml==20.4.0


### PR DESCRIPTION
sometimes we make changes to the tutorial code, but it takes a while for a new release to come out. So maybe better to just always use the latest planemo code from the master branch on GitHub

e.g. currently tutorial skeleton still generates old-style boxes even though we've updated the code

ping @hexylena @bebatut 

(not tested but hoping we have some tests here?)